### PR TITLE
Add option `subfolder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,3 +96,4 @@ failOnMissing | false | bool | If `true`, any undefined tag found in an HTML fil
 fallback | undefined | String | If given, will use the provided language as a fallback: For any other language, if a given tag's value is not provided, it will use the fallback language value.
 inline | undefined | String | If given, will use the provided language to create an output file of the same name as input. For example, passing `inline: 'en-US'` for `index.html` will result in `index.html` with English replacements.
 trace | false | bool | If `true`, will place comments in output HTML to show where the translated strings came from
+subfolder | false | String | If `createLangDirs` true and given, suffixes output path with given string

--- a/lib/index.js
+++ b/lib/index.js
@@ -215,7 +215,13 @@
               originPath = file.path;
               newFilePath = originPath.replace(/\.src\.html$/, '\.html');
               if (opt.createLangDirs) {
-                newFilePath = path.resolve(path.dirname(newFilePath), lang, path.basename(newFilePath));
+
+                if(opt.subfolder) {
+                    newFilePath = path.resolve(path.dirname(newFilePath), lang + opt.subfolder, path.basename(newFilePath));
+                } else {
+                    newFilePath = path.resolve(path.dirname(newFilePath), lang, path.basename(newFilePath));
+                }
+
               } else if (opt.inline) {
                 newFilePath = originPath;
               } else {


### PR DESCRIPTION
When `createLangDirs` is set to true the plugin discards the folder structure and writes all files flat to the destination folder.

-----

### Example:

Imagine the following structure

````
- /
   - index.html
   - misc/
        - about.html
```

The current state flattens the folder structure and would produce the following output:


````
- /
    - en/
        - index.html
        - about.html
   - de/
       - index.html
       - about.html
````

To keep the folder structure, we would introduce this subfolder option. For every folder you would like to keep, you would have to write a single gulp pipeline (See example below).

```
  return gulp.src(["./misc/*.html"])
    .pipe(i18n({
      langDir: './lang',
      createLangDirs: true,
      subfolder: '/misc/'
    }))
    .pipe(gulp.dest(dest));
```

Would produce:

````
- /
    - en/
        - misc/
             - about.html
   - de/
       - misc/
             - about.html
````

(I know this isn't the best solution to this problem, but maybe you could adjust the master branch to **not** flatten output)