### PR TITLE
Fix for https://github.com/webyom/gulp-html-i18n/issues/20

### DIFF
--- a/src/index.coffee
+++ b/src/index.coffee
@@ -259,6 +259,9 @@ module.exports = (opt = {}) ->
       return @emit 'error',
         new gutil.PluginError('gulp-html-i18n', 'Streams not supported')
 
+    if file.base && file.base.slice(-1) != '/'
+      file.base += '/'
+
     getLangResource(langDir, opt).then(
       (langResource) =>
         if file._lang_ && file.runId == runId

--- a/test/index.coffee
+++ b/test/index.coffee
@@ -43,6 +43,22 @@ describe 'gulp-html-i18n', ->
 
             testTranslation sourceFile, validator, cb
 
+        it 'replacement (trailing slash & windows)', (cb) ->
+            createLocaleFiles
+                '/en/new.json': '{ "hello" : "here" }'
+
+            sourceFile = new gutil.File
+                path: 'C:\\Projects\\Project\\src\\pages\\index.html',
+                base: 'C:\\Projects\\Project\\src\\pages'
+                contents: new Buffer 'Not there but ${{ new.hello }}$'
+
+            validator = (file) ->
+                file.path.should.equal 'C:\\Projects\\Project\\src\\pages/en/index.html'
+                file.contents.toString().should.equal 'Not there but here'
+
+            testTranslation sourceFile, validator, cb,
+                createLangDirs : true
+
         it 'replacement to folders', (cb) ->
             createLocaleFiles
                 '/en/new.json': '{ "hello" : "here" }'


### PR DESCRIPTION
file.base not haven't a trailing slash incorrectly makes new folder outputs
includes test