### PR TITLE
Fix border value check if value is a number

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,9 +34,10 @@
 
   wrapMustacheLookUp = function() {
     return mustache.Context.prototype.lookup = function(name) {
-      var value;
+      var type, value;
       value = this._lookup(name);
-      if (value === null || typeof value === 'undefined' || isNaN(value) || !isFinite(value)) {
+      type = typeof value;
+      if ((value === null || type === 'undefined') || (type === 'number' && !isFinite(value))) {
         this.handleUndefined(name, this.opt);
       }
       return value;

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -21,8 +21,9 @@ mustache.Context.prototype._lookup = mustache.Context.prototype.lookup
 wrapMustacheLookUp = ->
   mustache.Context.prototype.lookup = (name) ->
     value = this._lookup name
+    type = typeof(value)
 
-    if value == null || typeof(value) == 'undefined' || isNaN(value) || !isFinite(value)
+    if (value == null || type == 'undefined') || (type == 'number' && !isFinite(value))
       this.handleUndefined name, this.opt
     value
 
@@ -70,7 +71,7 @@ regexReplaceProperties = (langRegExp, delimiters, content, properties, opt, lv) 
         res = '*' + propName + '*'
       else
         res = '${{ ' + propName + ' }}$'
-    else 
+    else
       shouldBeProcessedAgain = langRegExp.test res
       if shouldBeProcessedAgain
         if lv > 3


### PR DESCRIPTION
Regarding issue #29, the PR #27 added checks in case a value is NaN or is not Finite, explanation contained in the respective PR.

The problem is that these checks were always being executed, even if they were not numbers.
So, for instance, if a value was correct, but was a string, it is considered a NaN, which would call the handleUndefined method, even though it was a correct value.

I added a simple check to the boolean expression to see if the value is in fact a number.
If it is, it will check for !isFinite.

I haven't found a test in which using isNaN makes sense, and if it is to be used, one should be careful and check on the type.
The reason why the test values were being considered undefined was because regular char strings were being tested to see if they were not a number (which they obviously are), and that should not be an error.

TL;DR:
Boolean values still work, which was the point of #27, and tests no longer are throwing undefined errors.
