### PR TITLE
#34 - fix fallback didn't work with custom delimiters

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -94,7 +94,7 @@
         } else if (!opt.fallback) {
           res = '*' + propName + '*';
         } else {
-          res = '${{ ' + propName + ' }}$';
+          res = delimiters[0] + ' ' + propName + ' ' + delimiters[1];
         }
       } else {
         shouldBeProcessedAgain = langRegExp.test(res);

--- a/src/index.coffee
+++ b/src/index.coffee
@@ -74,7 +74,7 @@ regexReplaceProperties = (langRegExp, delimiters, content, properties, opt, lv) 
       else if !opt.fallback
         res = '*' + propName + '*'
       else
-        res = '${{ ' + propName + ' }}$'
+        res = delimiters[0] + ' ' + propName + ' ' + delimiters[1]
     else
       shouldBeProcessedAgain = langRegExp.test res
       if shouldBeProcessedAgain


### PR DESCRIPTION
Fix to bypass bug described here https://github.com/webyom/gulp-html-i18n/issues/34.
It will work if using custom delimiters instead of langRegExp.